### PR TITLE
Add 'realer' package dep vuln checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 # Config file for automatic testing at travis-ci.org
-# This file will be regenerated if you run travis_pypi_setup.py
 
 language: python
 python: 3.7
@@ -28,8 +27,9 @@ matrix:
       python: 3.7
       env: TOXENV=py37
 
-# After you create the Github repo and add it to Travis, run the
-# travis_pypi_setup.py script to finish PyPI deployment setup
+    - name: Dependency vulnerability checks
+      env: TOXENV=safety
+
 deploy:
   provider: pypi
   distributions: sdist bdist_wheel

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,12 @@
 [tox]
-envlist = py27, py35, py36, py37
+envlist = py27, py35, py36, py37, safety
 
 [testenv]
 commands = pytest
 deps =
     pytest
     webtest
+
+[testenv:safety]
+commands = safety check
+deps = safety


### PR DESCRIPTION
The GH check doesn't check setup.py yet. The old requirements.txt file was just for test stuff, so it was actually wrong.

To be even safer, we should run this periodically, which can be configured in Travis.